### PR TITLE
Install "texinfo-ja.tex" to process Japanese Texinfo file

### DIFF
--- a/debian/texinfo.install
+++ b/debian/texinfo.install
@@ -17,4 +17,5 @@ usr/share/man/man1/pdftexi2dvi.1
 usr/share/man/man5/texinfo.5
 usr/share/texinfo
 usr/share/texmf/tex/texinfo/texinfo.tex
+usr/share/texmf/tex/texinfo/texinfo-ja.tex
 usr/share/texmf/tex/texinfo/txi-??.tex

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -64,6 +64,7 @@ install-tex:
 	test -n "$(TEXMF)" || (echo "TEXMF must be set." >&2; exit 1)
 	$(mkinstalldirs) $(DESTDIR)$(texmf_texinfo) $(DESTDIR)$(texmf_dvips)
 	$(INSTALL_DATA) $(srcdir)/texinfo.tex $(DESTDIR)$(texmf_texinfo)/texinfo.tex
+	$(INSTALL_DATA) $(srcdir)/texinfo-ja.tex $(DESTDIR)$(texmf_texinfo)/texinfo-ja.tex
 	$(INSTALL_DATA) $(srcdir)/epsf.tex $(DESTDIR)$(texmf_dvips)/epsf.tex
 	for f in $(TXI_XLATE); do \
 	  $(INSTALL_DATA) $(srcdir)/$$f $(DESTDIR)$(texmf_texinfo)/$$f; done

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -1842,6 +1842,7 @@ install-tex:
 	test -n "$(TEXMF)" || (echo "TEXMF must be set." >&2; exit 1)
 	$(mkinstalldirs) $(DESTDIR)$(texmf_texinfo) $(DESTDIR)$(texmf_dvips)
 	$(INSTALL_DATA) $(srcdir)/texinfo.tex $(DESTDIR)$(texmf_texinfo)/texinfo.tex
+	$(INSTALL_DATA) $(srcdir)/texinfo-ja.tex $(DESTDIR)$(texmf_texinfo)/texinfo-ja.tex
 	$(INSTALL_DATA) $(srcdir)/epsf.tex $(DESTDIR)$(texmf_dvips)/epsf.tex
 	for f in $(TXI_XLATE); do \
 	  $(INSTALL_DATA) $(srcdir)/$$f $(DESTDIR)$(texmf_texinfo)/$$f; done

--- a/doc/short-sample-ja.texi
+++ b/doc/short-sample-ja.texi
@@ -3,6 +3,8 @@
 @documentencoding UTF-8
 @documentlanguage ja
 
+@include version.texi
+
 @settitle サンプル マニュアル 1.0 日本語版
 
 @copying


### PR DESCRIPTION
`texinfo-ja.tex` is required for Japanese Texinfo files.

Use `doc/short-sample-ja.texi` for usage sample file.
