### PR TITLE
Add LuaTeX support patch

### DIFF
--- a/debian/patches/Update-LuaTeX-support
+++ b/debian/patches/Update-LuaTeX-support
@@ -1,0 +1,84 @@
+From: YOKOTA Hiroshi <qykth-git@users.noreply.github.com>
+Subject: [PATCH] Update LuaTeX support
+
+* Remove unexpected floating point number to support Lua 5.3+ based LuaTeX
+* Update LuaTeX hack
+
+---
+ doc/texinfo.tex |  8 ++++----
+ doc/txi-ja.tex  | 28 ----------------------------
+ 2 files changed, 4 insertions(+), 32 deletions(-)
+
+Index: b/doc/texinfo.tex
+===================================================================
+--- a/doc/texinfo.tex
++++ b/doc/texinfo.tex
+@@ -3,7 +3,7 @@
+ % Load plain if necessary, i.e., if running under initex.
+ \expandafter\ifx\csname fmtname\endcsname\relax\input plain\fi
+ %
+-\def\texinfoversion{2019-09-08.12}
++\def\texinfoversion{2019-09-20.22}
+ %
+ % Copyright 1985, 1986, 1988, 1990-2019 Free Software Foundation, Inc.
+ %
+@@ -1052,7 +1052,7 @@ where each line of input produces a line
+             tex.sprint(
+               string.format(string.char(0x5c) .. string.char(0x25) .. '03o' ..
+                             string.char(0x5c) .. string.char(0x25) .. '03o',
+-                            (c / 256), (c % 256)))
++                            math.floor(c / 256), math.floor(c % 256)))
+           else
+             c = c - 0x10000
+             local c_hi = c / 1024 + 0xd800
+@@ -1062,8 +1062,8 @@ where each line of input produces a line
+                             string.char(0x5c) .. string.char(0x25) .. '03o' ..
+                             string.char(0x5c) .. string.char(0x25) .. '03o' ..
+                             string.char(0x5c) .. string.char(0x25) .. '03o',
+-                            (c_hi / 256), (c_hi % 256),
+-                            (c_lo / 256), (c_lo % 256)))
++                            math.floor(c_hi / 256), math.floor(c_hi % 256),
++                            math.floor(c_lo / 256), math.floor(c_lo % 256)))
+           end
+         end
+       end
+Index: b/doc/txi-ja.tex
+===================================================================
+--- a/doc/txi-ja.tex
++++ b/doc/txi-ja.tex
+@@ -191,21 +191,6 @@
+         #1%
+         \parseargline\empty% Insert the \empty token, see \finishparsearg below.
+     }
+-    % Re-define texinfo.tex's \comment
+-    \def\comment{\begingroup \catcode`\^^M=\active%
+-      \ifx\ltjlineendcomment\thisisundefined
+-        % Ignore U+FFFFF for LuaTeX-ja <= 20160208.0
+-        \catcode"FFFFF=9%
+-      \else
+-        % Ignore the character \ltjlineendcomment for LuaTeX-ja > 20160208.0
+-        \catcode\ltjlineendcomment=9%
+-      \fi
+-    \catcode`\@=\other \catcode`\{=\other \catcode`\}=\other\commentxxx}%
+-    % Re-let \comment related macros
+-    \let\setfilename=\comment
+-    \let\dircategory=\comment
+-    \let\definfoenclose=\comment
+-    \let\footnotestyle=\comment
+     % Re-define texinfo.tex's \c
+     \def\c{\begingroup \catcode`\^^M=\active%
+       \ifx\ltjlineendcomment\thisisundefined
+@@ -218,7 +203,12 @@
+     \catcode`\@=\other \catcode`\{=\other \catcode`\}=\other%
+     \cxxx}
+     % Re-let \c related macro
+-    \let\texinfoc=\c
++    \let\comment=\c
++    % Re-let \comment related macros
++    \let\setfilename=\comment
++    \let\dircategory=\comment
++    \let\definfoenclose=\comment
++    \let\footnotestyle=\comment
+   \fi % LuaTeX
+ 
+   %

--- a/debian/patches/install-texinfo-ja
+++ b/debian/patches/install-texinfo-ja
@@ -8,8 +8,10 @@ See GH PR https://github.com/debian-tex/texinfo/pull/1
  doc/short-sample-ja.texi |    2 ++
  3 files changed, 4 insertions(+)
 
---- texinfo.orig/doc/Makefile.am
-+++ texinfo/doc/Makefile.am
+Index: b/doc/Makefile.am
+===================================================================
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
 @@ -64,6 +64,7 @@ install-tex:
  	test -n "$(TEXMF)" || (echo "TEXMF must be set." >&2; exit 1)
  	$(mkinstalldirs) $(DESTDIR)$(texmf_texinfo) $(DESTDIR)$(texmf_dvips)
@@ -18,8 +20,10 @@ See GH PR https://github.com/debian-tex/texinfo/pull/1
  	$(INSTALL_DATA) $(srcdir)/epsf.tex $(DESTDIR)$(texmf_dvips)/epsf.tex
  	for f in $(TXI_XLATE); do \
  	  $(INSTALL_DATA) $(srcdir)/$$f $(DESTDIR)$(texmf_texinfo)/$$f; done
---- texinfo.orig/doc/Makefile.in
-+++ texinfo/doc/Makefile.in
+Index: b/doc/Makefile.in
+===================================================================
+--- a/doc/Makefile.in
++++ b/doc/Makefile.in
 @@ -1855,6 +1855,7 @@ install-tex:
  	test -n "$(TEXMF)" || (echo "TEXMF must be set." >&2; exit 1)
  	$(mkinstalldirs) $(DESTDIR)$(texmf_texinfo) $(DESTDIR)$(texmf_dvips)
@@ -28,8 +32,10 @@ See GH PR https://github.com/debian-tex/texinfo/pull/1
  	$(INSTALL_DATA) $(srcdir)/epsf.tex $(DESTDIR)$(texmf_dvips)/epsf.tex
  	for f in $(TXI_XLATE); do \
  	  $(INSTALL_DATA) $(srcdir)/$$f $(DESTDIR)$(texmf_texinfo)/$$f; done
---- texinfo.orig/doc/short-sample-ja.texi
-+++ texinfo/doc/short-sample-ja.texi
+Index: b/doc/short-sample-ja.texi
+===================================================================
+--- a/doc/short-sample-ja.texi
++++ b/doc/short-sample-ja.texi
 @@ -3,6 +3,8 @@
  @documentencoding UTF-8
  @documentlanguage ja
@@ -39,3 +45,18 @@ See GH PR https://github.com/debian-tex/texinfo/pull/1
  @settitle サンプル マニュアル 1.0 日本語版
  
  @copying
+@@ -21,14 +23,12 @@ Copyright @copyright{} 2016 Free Softwar
+ @c 最初に目次を出力します。
+ @contents
+ 
+-@ifnottex
+ @node Top
+ @top GNU サンプル
+ 
+ このマニュアルは GNU サンプル
+ (version @value{VERSION}, @value{UPDATED})
+ 用です。
+-@end ifnottex
+ 
+ @menu
+ * 第一章::           第一章は

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ info-manpage-mentiones-nonfree
 #Update-locale-handling-for-Perl-5.28
 upstream_patch_texi2any_pl
 install-texinfo-ja
+Update-LuaTeX-support


### PR DESCRIPTION
This patch update updates Lua 5.3+ based LuaTeX support and fixes some errors that commented #1 .
It also includes some small update to sample .texi file that works "texi2any" command well.

FYI:
If you want real-world usage of Japanese texinfo, checkout [Gauche](https://github.com/shirok/Gauche) .
They written their Japanese documents with texinfo.