### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -8,6 +8,8 @@ texinfo (6.7.0.dfsg.2-6) UNRELEASED; urgency=medium
   * Rely on pre-initialized dpkg-architecture variables.
   * Fix day-of-week for changelog entry 4.8-2.
   * Update standards version to 4.5.0, no changes needed.
+  * Remove Section on info, Section on install-info that duplicate
+    source.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 27 Apr 2020 03:58:22 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,6 @@ Description: Documentation system for on-line information and printed output
  Info file with nodes, menus, cross references, and indices.
 
 Package: info
-Section: doc
 Priority: important
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, install-info
@@ -47,7 +46,6 @@ Description: Standalone GNU Info documentation browser
  the form of Info files, so it is most likely you will want to install it.
 
 Package: install-info
-Section: doc
 Priority: important
 Architecture: any
 Pre-Depends: dpkg (>= 1.16.1)


### PR DESCRIPTION
Fix some issues reported by lintian
* Trim trailing whitespace. ([file-contains-trailing-whitespace](https://lintian.debian.org/tags/file-contains-trailing-whitespace.html))
* Bump debhelper from deprecated 9 to 12. ([package-uses-deprecated-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-deprecated-debhelper-compat-version.html))
* Set debhelper-compat version in Build-Depends. ([uses-debhelper-compat-file](https://lintian.debian.org/tags/uses-debhelper-compat-file.html))
* Set upstream metadata fields: Bug-Submit (from ./configure), Name (from ./configure). ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html))
* Rely on pre-initialized dpkg-architecture variables. ([debian-rules-sets-dpkg-architecture-variable](https://lintian.debian.org/tags/debian-rules-sets-dpkg-architecture-variable.html))
* Fix day-of-week for changelog entry 4.8-2. ([debian-changelog-has-wrong-day-of-week](https://lintian.debian.org/tags/debian-changelog-has-wrong-day-of-week.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))
* Remove Section on info, Section on install-info that duplicate source. ([binary-control-field-duplicates-source](https://lintian.debian.org/tags/binary-control-field-duplicates-source.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/texinfo/59241d56-6b55-48c2-9310-7d0fe30b6d4d.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/59241d56-6b55-48c2-9310-7d0fe30b6d4d/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/59241d56-6b55-48c2-9310-7d0fe30b6d4d/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/59241d56-6b55-48c2-9310-7d0fe30b6d4d/diffoscope)).
