### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,18 @@
 texinfo (6.8-5) UNRELEASED; urgency=medium
 
+  [ Hilmar Preusse ]
   * Call dh_lintian in d/rules to actually install overrides.
   * Fix a few lintian complains, add overrides.
   * Replace "which" by "command -v" (Closes: #1003577)
+
+  [ Debian Janitor ]
+  * Remove constraints unnecessary since buster:
+    + texinfo: Drop versioned constraint on tex-common in Depends.
+    + info: Drop versioned constraint on texinfo in Replaces.
+    + install-info: Drop versioned constraint on dpkg in Pre-Depends.
+    + install-info: Drop versioned constraint on texinfo in Replaces.
+    + install-info: Drop versioned constraint on texinfo in Breaks.
+    + Remove 1 maintscript entries from 1 files.
 
  -- Hilmar Preusse <hille42@web.de>  Tue, 11 Jan 2022 17:17:28 +0100
 

--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Package: texinfo
 Section: text
 Priority: optional
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, libtext-unidecode-perl, libxml-libxml-perl, tex-common (>= 6)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, libtext-unidecode-perl, libxml-libxml-perl, tex-common
 Suggests: texlive-base, texlive-latex-base, texlive-plain-generic, texlive-fonts-recommended
 Breaks: tetex-bin (<< 3.0), tetex-base (<< 3.0), ja-trans (<= 0.7-3.1), texinfo-doc-nonfree
 Replaces: tetex-base (<< 1.0.2+20000804-9), tetex-bin (<< 3.0), texinfo-doc-nonfree
@@ -36,7 +36,7 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, install-info
 Provides: info-browser
 Breaks: texinfo-doc-nonfree
-Replaces: texinfo (<< 4.7-2), texinfo-doc-nonfree
+Replaces: texinfo-doc-nonfree
 Multi-Arch: foreign
 Description: Standalone GNU Info documentation browser
  The Info file format is an easily-parsable representation for online
@@ -49,9 +49,6 @@ Description: Standalone GNU Info documentation browser
 Package: install-info
 Priority: important
 Architecture: any
-Pre-Depends: dpkg (>= 1.16.1)
-Replaces: texinfo (<< 4.13a.dfsg.1-2)
-Breaks: texinfo (<< 4.13a.dfsg.1-2)
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: foreign
 Description: Manage installed documentation in info format

--- a/debian/texinfo.maintscript
+++ b/debian/texinfo.maintscript
@@ -1,1 +1,0 @@
-rm_conffile /etc/texmf/fmt.d/50cyrtexinfo.cnf 5.9.92.dfsg.1-1~


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/texinfo/7c0c9d15-dbb5-4574-a784-6bd71722e2a1.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in first set of .debs but not in second
    -rwxr-xr-x  root/root   DEBIAN/preinst
### Control files of package info: lines which differ (wdiff format)
* Replaces: [-texinfo (<< 4.7-2),-] texinfo-doc-nonfree

No differences were encountered between the control files of package \*\*info-dbgsym\*\*
### Control files of package install-info: lines which differ (wdiff format)
* [-Breaks: texinfo (<< 4.13a.dfsg.1-2)-]
* [-Pre-Depends: dpkg (>= 1.16.1)-]
* [-Replaces: texinfo (<< 4.13a.dfsg.1-2)-]

No differences were encountered between the control files of package \*\*install-info-dbgsym\*\*
### Control files of package texinfo: lines which differ (wdiff format)
* Depends: libc6 (>= 2.33), perl, perlapi-5.34.0, libtext-unidecode-perl, libxml-libxml-perl, tex-common [-(>= 6)-]

No differences were encountered between the control files of package \*\*texinfo-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/7c0c9d15-dbb5-4574-a784-6bd71722e2a1/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/7c0c9d15-dbb5-4574-a784-6bd71722e2a1/diffoscope)).
