### PR TITLE
fix: modify priority from important tooptional of package info and in…

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -63,7 +63,7 @@ Description: Libraries needed by the texinfo package
  This package contains the architecture dependent parts of the texinfo package.
 
 Package: info
-Priority: important
+Priority: optional
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, install-info
 Provides: info-browser
@@ -79,7 +79,7 @@ Description: Standalone GNU Info documentation browser
  the form of Info files, so it is most likely you will want to install it.
 
 Package: install-info
-Priority: important
+Priority: optional
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: foreign


### PR DESCRIPTION
…stall-info

The lack of installation of the info and install info software packages does not affect system operation. This important priority does not comply with the debian package specification

Log:  modify priority from important tooptional of package info and install-info